### PR TITLE
Update to use current Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
         <configuration>
           <archive>
             <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <url>https://github.com/jenkinsci/extras-client-demo/</url>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/extras-client-demo.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/extras-client-demo.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/extras-client-demo.git</developerConnection>
     <url>https://github.com/jenkinsci/extras-client-demo</url>
   </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -86,12 +86,5 @@
         </executions>
       </plugin>
     </plugins>
-    <extensions>
-      <extension>
-        <groupId>org.jvnet.wagon-svn</groupId>
-        <artifactId>wagon-svn</artifactId>
-        <version>1.8</version>
-      </extension>
-    </extensions>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -37,14 +37,6 @@
     </dependency>
   </dependencies>
 
-  <repositories>
-    <repository>
-      <id>maven2-repository.dev.java.net</id>
-      <name>Java.net Repository for Maven</name>
-      <url>http://download.java.net/maven/2/</url>
-    </repository>
-  </repositories>
-
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-        </configuration>
+        <version>3.8.1</version>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <name>XML API client demo</name>
   <inceptionYear>2006</inceptionYear>
   <description>Demonstrates how to write a client for the remote API</description>
-  <url>https://hudson.dev.java.net/</url>
+  <url>https://github.com/jenkinsci/extras-client-demo/</url>
 
   <scm>
     <connection>scm:cvs:pserver:guest@cvs.dev.java.net:/cvs:hudson/hudson/extras/client-demo</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
   <url>https://github.com/jenkinsci/extras-client-demo/</url>
 
   <scm>
-    <connection>scm:cvs:pserver:guest@cvs.dev.java.net:/cvs:hudson/hudson/extras/client-demo</connection>
-    <developerConnection>scm:cvs:pserver:kohsuke@cvs.dev.java.net:/cvs:hudson/hudson/extras/client-demo</developerConnection>
-    <url>https://hudson.dev.java.net/source/browse/hudson/hudson/extras/client-demo</url>
+    <connection>scm:git:git://github.com/jenkinsci/extras-client-demo.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/extras-client-demo.git</developerConnection>
+    <url>https://github.com/jenkinsci/extras-client-demo</url>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
Example repository is referenced from the Remote Access API wiki page.  Initial proposal is to remove the reference to this repository from that page when it is converted to www.jenkins.io.  If that decision does not "stick", then these changes will be needed so that the code compiles again.